### PR TITLE
Add multi-region reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ settings:
   daily_summary: "09:00"     # Daily summary time (local)
   weekly_summary: "monday 09:00" # Weekly summary schedule (local)
   public_dashboard: true      # Enable the web dashboard
+  region: "us-east-1"         # Region name for multi-region checks
+  coordinator_url: ""         # Coordinator URL (agent mode)
+  regions_required: 2         # Minimum regions to alert
+  region_alerts: false        # Coordinator sends per-region alerts
 ```
 
 ### Maintenance Windows
@@ -212,6 +216,10 @@ Override settings via env:
 - `PORT`
 - `METRICS_PORT`
 - `PUBLIC_DASHBOARD`
+- `REGION`
+- `COORDINATOR_URL`
+- `REGIONS_REQUIRED`
+- `REGION_ALERTS`
 
 ## Prometheus Metrics
 
@@ -224,6 +232,25 @@ The dashboard is served at `/` and `/dashboard` when enabled. It provides real-t
 API endpoints:
 - `/api/summary` for status and aggregate metrics
 - `/api/history` for response history and incidents
+
+## Multi-Region Checks
+
+Run multiple Pulse agents and point them at a coordinator for aggregated alerting.
+
+Coordinator:
+```yaml
+settings:
+  region: "coordinator"
+  regions_required: 2
+  region_alerts: true
+```
+
+Agent:
+```yaml
+settings:
+  region: "us-east-1"
+  coordinator_url: "http://coordinator:8080"
+```
 
 ## Webhook Notifications
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ settings:
   coordinator_url: ""         # Coordinator URL (agent mode)
   regions_required: 2         # Minimum regions to alert
   region_alerts: false        # Coordinator sends per-region alerts
+  report_stale_after: "5m"    # Ignore stale region reports
 ```
 
 ### Maintenance Windows
@@ -220,6 +221,7 @@ Override settings via env:
 - `COORDINATOR_URL`
 - `REGIONS_REQUIRED`
 - `REGION_ALERTS`
+- `REPORT_STALE_AFTER`
 
 ## Prometheus Metrics
 

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ settings:
   coordinator_url: ""
   regions_required: 2
   region_alerts: false
+  report_stale_after: "5m"
 
 endpoints:
   # Simple HTTP health check

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,10 @@ settings:
   daily_summary: "09:00"
   weekly_summary: "monday 09:00"
   public_dashboard: true
+  region: "us-east-1"
+  coordinator_url: ""
+  regions_required: 2
+  region_alerts: false
 
 endpoints:
   # Simple HTTP health check

--- a/main_test.go
+++ b/main_test.go
@@ -156,3 +156,21 @@ func TestIsWithinWeeklyWindow(t *testing.T) {
 		t.Fatalf("expected outside maintenance window")
 	}
 }
+
+func TestBuildRegionReport(t *testing.T) {
+	config := Config{}
+	config.Settings.Region = "us-east-1"
+	config.Endpoints = []Endpoint{{Name: "api"}}
+
+	monitor := NewMonitor(config)
+	monitor.statuses["api"] = &EndpointStatus{IsUp: true, ResponseTime: 50 * time.Millisecond}
+
+	report := monitor.BuildRegionReport()
+	if report.Region != "us-east-1" {
+		t.Fatalf("expected region us-east-1, got %s", report.Region)
+	}
+	status, ok := report.Statuses["api"]
+	if !ok || !status.Up {
+		t.Fatalf("expected api status to be up")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -174,3 +174,35 @@ func TestBuildRegionReport(t *testing.T) {
 		t.Fatalf("expected api status to be up")
 	}
 }
+
+func TestEvaluateAggregatesStaleReports(t *testing.T) {
+	config := Config{}
+	config.Settings.RegionsRequired = 2
+	config.Settings.ReportStaleAfter = "1m"
+	config.Endpoints = []Endpoint{{Name: "API"}}
+
+	monitor := NewMonitor(config)
+	monitor.regionReports["API"] = map[string]RegionStatus{
+		"us": {Up: false},
+		"eu": {Up: false},
+	}
+	now := time.Now()
+	monitor.regionLastReport["us"] = now.Add(-2 * time.Minute)
+	monitor.regionLastReport["eu"] = now
+
+	monitor.mu.Lock()
+	alerts := monitor.evaluateAggregatesLocked(now)
+	monitor.mu.Unlock()
+	if len(alerts) != 0 {
+		t.Fatalf("expected no alerts for stale reports")
+	}
+
+	monitor.regionLastReport["us"] = now
+	monitor.regionReports["API"]["us"] = RegionStatus{Up: false}
+	monitor.mu.Lock()
+	alerts = monitor.evaluateAggregatesLocked(now)
+	monitor.mu.Unlock()
+	if len(alerts) == 0 {
+		t.Fatalf("expected aggregate alert when both regions report down")
+	}
+}


### PR DESCRIPTION
## Summary
- add coordinator/agent settings for multi-region checks
- aggregate region reports and alert only when multiple regions are down
- document multi-region configuration and environment overrides

## Testing
- go test ./...

## Issue
- Closes #6